### PR TITLE
Fix(upload): Make sure _fetchRevisionManifest works if the manifest is empty

### DIFF
--- a/lib/ssh-client.js
+++ b/lib/ssh-client.js
@@ -20,7 +20,7 @@ module.exports = CoreObject.extend({
     }
 
     this.options = options;
-    this.client  = new SSH2Client();  
+    this.client  = new SSH2Client();
   },
 
 
@@ -55,9 +55,9 @@ module.exports = CoreObject.extend({
         if (error) {
           reject(error);
         }
-        
+
         var stream = sftp.createWriteStream(path);
-        
+
         stream.on('error', reject);
         stream.on('finish', resolve);
         stream.write(data);
@@ -90,10 +90,11 @@ module.exports = CoreObject.extend({
 
   exec: function(command) {
     var client = this.client;
+
     return new Promise(function(resolve, reject) {
-      client.exec(command, function(err/*, stream*/) {
-        if (err) {
-          reject(err);
+      client.exec(command, function(error/*, stream*/) {
+        if (error) {
+          reject(error);
         }
         resolve();
       });
@@ -117,7 +118,7 @@ module.exports = CoreObject.extend({
             if (err) {
               reject(err);
             }
-             
+
             sftp.fastPut(src, dest, {}, function (err) {
               if (err) {
                 reject(err);


### PR DESCRIPTION
If there was a previous error writing the revisions manifest file the deployment would be stuck because of an unhandled JSON.parse error. I used the promises of the client instead of creating new ones. Now we get error messages even for the success callbacks.

Please don't merge yet. Because the error is "kind of random" I'll test more with bad latency and let you know if it works.