### PR TITLE
Fix `ember-cli/ext/promise` Deprecation for Ember CLI >=2.12.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
 'use strict';
 
-var Promise          = require('ember-cli/lib/ext/promise');
+var Promise          = require('rsvp').Promise;
 var DeployPluginBase = require('ember-cli-deploy-plugin');
 var path             = require('path');
 var os               = require('os');

--- a/lib/ssh-client.js
+++ b/lib/ssh-client.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var CoreObject = require('core-object');
-var Promise    = require('ember-cli/lib/ext/promise');
+var Promise    = require('rsvp').Promise;
 var SSH2Client = require('ssh2').Client;
 var fs         = require('fs');
 var untildify  = require('untildify');

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "core-object": "^1.1.0",
     "ember-cli-deploy-plugin": "^0.2.9",
     "lodash": "^3.10.1",
-    "untildify": "^2.1.0",
     "node-fs": "^0.1.7",
+    "rsvp": "^3.5.0",
     "ssh2": "^0.5.0",
+    "untildify": "^2.1.0",
     "username": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This resolves the deprecation warning:

```
DEPRECATION: `ember-cli/ext/promise` is deprecated, use `rsvp` instead...
```