### PR TITLE
Close sftp channels/connections

### DIFF
--- a/lib/ssh-client.js
+++ b/lib/ssh-client.js
@@ -60,6 +60,9 @@ module.exports = CoreObject.extend({
 
         stream.on('error', reject);
         stream.on('finish', resolve);
+        stream.on('close', function() {
+          sftp.end();
+        });
         stream.write(data);
         stream.end();
       });
@@ -77,6 +80,8 @@ module.exports = CoreObject.extend({
         }
 
         sftp.readFile(path, {}, function (error, data) {
+          sftp.end();
+
           if (error) {
             reject(error);
           } else {
@@ -120,6 +125,8 @@ module.exports = CoreObject.extend({
             }
 
             sftp.fastPut(src, dest, {}, function (err) {
+              sftp.end();
+
               if (err) {
                 reject(err);
               }


### PR DESCRIPTION
Like https://github.com/arenoir/ember-cli-deploy-ssh2/pull/15 explains the addon opens too many connections to the server. I closed the sftp connections to not have too many open channels/connections.

A new release would be great if you agree on the changes.